### PR TITLE
Change fog dep to fog-aws ~> 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,4 @@ cache: bundler
 rvm:
 - 2.1.1
 - 1.9.3
-- jruby-19mode
 script: bundle exec rake test --trace

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ language: ruby
 cache: bundler
 rvm:
 - 2.1.1
-- 1.9.2
 - 1.9.3
 - jruby-19mode
 script: bundle exec rake test --trace

--- a/fog-bouncer.gemspec
+++ b/fog-bouncer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "clamp", "~> 0.5.0"
   gem.add_dependency "clarence", "1987.0.0"
-  gem.add_dependency "fog", "~> 1.2"
+  gem.add_dependency "fog-aws", "~> 0.6"
   gem.add_dependency "ipaddress", "~> 0.8.0"
   gem.add_dependency "jruby-openssl", "~> 0.7.6" if RUBY_PLATFORM == "java"
   gem.add_dependency "rake", "~> 0.9.0"

--- a/lib/fog/bouncer.rb
+++ b/lib/fog/bouncer.rb
@@ -1,4 +1,4 @@
-require "fog"
+require "fog/aws"
 require "fog/bouncer/group"
 require "fog/bouncer/protocols"
 require "fog/bouncer/security"

--- a/lib/fog/bouncer/version.rb
+++ b/lib/fog/bouncer/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Bouncer
-    VERSION = "0.2.7"
+    VERSION = "0.3.0-pre"
   end
 end


### PR DESCRIPTION
I found that depending on `fog` ends up creating a dependency on _lots_ of fog gems. These result in building unused native extensions and generally including lots of code that is unused.

Since fog bouncer only works on AWS this updates the dependency from fog to `fog-aws`

This was done to reduce deps in ion.

https://github.com/heroku/ion/pull/1804

Added you @mikehale, in part, because you are listed as an owner on https://rubygems.org/gems/fog-bouncer/versions/0.2.7

I'll adjust version numbers to drop the `-pre` if we're happy with it.