### PR TITLE
Update fog-bouncer gemspec deps

### DIFF
--- a/fog-bouncer.gemspec
+++ b/fog-bouncer.gemspec
@@ -15,12 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Fog::Bouncer::VERSION
 
-  gem.add_dependency "clamp", "~> 0.5.0"
-  gem.add_dependency "clarence", "1987.0.0"
-  gem.add_dependency "fog-aws", "~> 0.6"
-  gem.add_dependency "ipaddress", "~> 0.8.0"
-  gem.add_dependency "jruby-openssl", "~> 0.7.6" if RUBY_PLATFORM == "java"
-  gem.add_dependency "rake", "~> 0.9.0"
+  gem.add_dependency "clamp"
+  gem.add_dependency "fog-aws"
+  gem.add_dependency "ipaddress"
+  gem.add_dependency "rake"
   gem.add_dependency "scrolls", "~> 0.2.1"
 
   gem.add_development_dependency "minitest"

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,8 +1,3 @@
-if ENV['TRAVIS_PULL_REQUEST'] && ["1", "true"].include?(ENV['TRAVIS_PULL_REQUEST']) && ENV['FOG_REAL'] && ["1", "true"].include?(ENV['FOG_REAL'])
-  require "clarence"
-  Bitches.leave
-end
-
 require "simplecov" unless ENV['NO_SIMPLECOV']
 require 'minitest/autorun'
 


### PR DESCRIPTION
* Remove clarence as it isn't actually used
* Remove JRuby support
* Relax some dependency versions